### PR TITLE
Armor penalty fixes

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -648,7 +648,9 @@ export class ExpanseActorSheet extends ActorSheet {
             let condModName;
             let rollCard;
             let condModWarning;
+            let armorPenaltyWarning;
             let resultsSum;
+            let armorPenalty = 0;
             let useFocusPlus = 0;
             // need to conditionally set d2 d1. if game.module for dsn is true, use the dice data, if not use 6;
             if (game.modules.get("dice-so-nice") && game.modules.get("dice-so-nice").active) {
@@ -664,14 +666,21 @@ export class ExpanseActorSheet extends ActorSheet {
             if (roll.data.abilities[dataset.label].usefocus === true && roll.data.abilities[dataset.label].usefocusplus === true) {
                 useFocusPlus = 1
             }
+            if (dataset.label === 'dexterity' && roll.data.abilities[dataset.label].usePenalty === true) {
+                armorPenalty = roll.data.attributes.penalty.modified
+            }
+
             let abilityMod = roll.data.abilities[dataset.label].rating;
             [die1, die2] = roll.terms[0].results.map(i => i.result);
             [die3] = roll.terms[2].results.map(i => i.result);
 
-            if (roll.data.conditions.wounded.active === true) {
+
+            //TODO: Should probably roll these roll modifiers into it's own function and then localize it
+
+            if (roll.data.conditions.wounded.active === "true") {
                 condMod = -2;
                 condModName = "wounded";
-            } else if ((roll.data.conditions.injured.active === true) && (roll.data.conditions.wounded.active === false)) {
+            } else if ((roll.data.conditions.injured.active === "true") && (roll.data.conditions.wounded.active === false)) {
                 condMod = -1;
                 condModName = "injured";
             } else {
@@ -685,6 +694,13 @@ export class ExpanseActorSheet extends ActorSheet {
             } else {
                 condModWarning = ``;
             }
+
+            if(armorPenalty < 0) {
+                armorPenaltyWarning = `<i>Your armor is restrictive and receive a ${armorPenalty} modifier to your roll</i> <br>`;
+            } else {
+                armorPenaltyWarning = ``;
+            }
+
 
             const dieImage = `<img height="75px" width="75px" src="systems/expanse/ui/dice/${diceData.faction}/chat/${diceData.faction}-${die1}-${diceData.style}.png" />
             <img height="75px" width="75px" src="systems/expanse/ui/dice/${diceData.faction}/chat/${diceData.faction}-${die2}-${diceData.style}.png" />
@@ -700,7 +716,7 @@ export class ExpanseActorSheet extends ActorSheet {
 
             let chatMod = `<b>Ability Rating</b>: ${abilityMod}</br>`;
 
-            resultsSum = die1 + die2 + die3 + useFocus + useFocusPlus + abilityMod + condMod;
+            resultsSum = die1 + die2 + die3 + useFocus + useFocusPlus + abilityMod + condMod + armorPenalty;
 
             // Stunt Points Generation
             let chatStunts = "";
@@ -723,7 +739,8 @@ export class ExpanseActorSheet extends ActorSheet {
                         ${chatMod}
                         ${chatAddMod}
                         ${chatFocus}
-                        ${condModWarning} 
+                        ${condModWarning}
+                        ${armorPenaltyWarning} 
                         <b>Ability Test Results:</b> ${resultsSum} <br> 
                         ${chatStunts}
                     `
@@ -743,6 +760,7 @@ export class ExpanseActorSheet extends ActorSheet {
                 ${chatMod}
                 ${chatFocus}
                 ${condModWarning} 
+                ${armorPenaltyWarning}
                 <b>Ability Test Results:</b> ${resultsSum} <br> 
                 ${chatStunts}`
 

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -179,7 +179,10 @@ export class ExpanseActorSheet extends ActorSheet {
         html.find(".item-equip").click(async e => {
             const data = super.getData()
             const items = data.items;
+
+
             let itemId = e.currentTarget.getAttribute("data-item-id");
+            let itemType = data.items.find(i => i._id == itemId).type;
 
             for (let [k, v] of Object.entries(items)) {
                 let curArmor = duplicate(this.actor.getEmbeddedDocument("Item", v._id));
@@ -195,21 +198,16 @@ export class ExpanseActorSheet extends ActorSheet {
                     return;
                 }*/
                 // If targeting same armor, cycle on off;
-
-                if (v.type === "armor" && v._id === itemId) {
-                    curArmor.data.equip =  !curArmor.data.equip
-                } else if (v.type === "armor") {
-                    curArmor.data.equip =  false
-                }
-
-
-                if (v.type === "shield" && v._id === itemId) {
-                    curArmor.data.equip = !curArmor.data.equip;
-                } else if (v.type === "shield") {
-                    curArmor.data.equip =  false
+                if (v.type === itemType ) {
+                    if (v._id === itemId) {
+                        curArmor.data.equip = !curArmor.data.equip;
+                    } else {
+                        curArmor.data.equip = false
+                    }
                 }
 
                 this.actor.updateEmbeddedDocuments("Item", [curArmor]);
+
             }
         });
 

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -686,10 +686,10 @@ export class ExpanseActorSheet extends ActorSheet {
 
             //TODO: Should probably roll these roll modifiers into it's own function and then localize it
 
-            if (roll.data.conditions.wounded.active === "true") {
+            if (roll.data.conditions.wounded.active === true) {
                 condMod = -2;
                 condModName = "wounded";
-            } else if ((roll.data.conditions.injured.active === "true") && (roll.data.conditions.wounded.active === false)) {
+            } else if ((roll.data.conditions.injured.active === true) && (roll.data.conditions.wounded.active === false)) {
                 condMod = -1;
                 condModName = "injured";
             } else {

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -179,11 +179,11 @@ export class ExpanseActorSheet extends ActorSheet {
         html.find(".item-equip").click(async e => {
             const data = super.getData()
             const items = data.items;
-
             let itemId = e.currentTarget.getAttribute("data-item-id");
-            const armor = duplicate(this.actor.getEmbeddedDocument("Item", itemId));
 
             for (let [k, v] of Object.entries(items)) {
+                let curArmor = duplicate(this.actor.getEmbeddedDocument("Item", v._id));
+
                 // Confirming only one armour equipped
                 /*if ((v.type === "armor" || v.type === "shield") && v.data.equip === true && v._id !== itemId) {
                     Dialog.prompt({
@@ -195,12 +195,21 @@ export class ExpanseActorSheet extends ActorSheet {
                     return;
                 }*/
                 // If targeting same armor, cycle on off;
+
                 if (v.type === "armor" && v._id === itemId) {
-                    armor.data.equip = !armor.data.equip;
-                } else if (v.type === "shield" && v._id === itemId) {
-                    armor.data.equip = !armor.data.equip;
+                    curArmor.data.equip =  !curArmor.data.equip
+                } else if (v.type === "armor") {
+                    curArmor.data.equip =  false
                 }
-                this.actor.updateEmbeddedDocuments("Item", [armor])
+
+
+                if (v.type === "shield" && v._id === itemId) {
+                    curArmor.data.equip = !curArmor.data.equip;
+                } else if (v.type === "shield") {
+                    curArmor.data.equip =  false
+                }
+
+                this.actor.updateEmbeddedDocuments("Item", [curArmor]);
             }
         });
 

--- a/module/actor.js
+++ b/module/actor.js
@@ -72,13 +72,13 @@ export class ExpanseActor extends Actor {
     const data = actorData.data;
     if (actorData.type === "character") {
 
+      actorData.data.attributes.armor.modified = 0;
+      actorData.data.attributes.penalty.modified = 0;
+
       for (let items of actorData.items) {
         if (items.data.type === "armor" && items.data.data.equip === true) {
           actorData.data.attributes.armor.modified = Number(items.data.data.bonus);
           actorData.data.attributes.penalty.modified = Number(items.data.data.penalty);
-        } else if (items.data.type === "armor" && items.data.data.equip === false) {
-          actorData.data.attributes.armor.modified = actorData.data.attributes.armor.value;
-          actorData.data.attributes.penalty.modified = actorData.data.attributes.penalty.value;
         }
         //shields
         if (items.data.type === "shield" && items.data.data.equip === true) {
@@ -88,7 +88,7 @@ export class ExpanseActor extends Actor {
 
 
 
-      data.attributes.speed.modified = 10 + Number(data.abilities.dexterity.rating);
+      data.attributes.speed.modified = 10 + Number(data.abilities.dexterity.rating) + Number(data.attributes.penalty.modified);
       data.attributes.defense.modified = 10 + Number(data.abilities.dexterity.rating) + Number(data.attributes.defense.bonus);
       data.attributes.toughness.modified = Number(data.abilities.constitution.rating);
       data.attributes.move.modified = Number(data.attributes.speed.modified);

--- a/module/actor.js
+++ b/module/actor.js
@@ -74,6 +74,7 @@ export class ExpanseActor extends Actor {
 
       actorData.data.attributes.armor.modified = 0;
       actorData.data.attributes.penalty.modified = 0;
+      actorData.data.attributes.defense.bonus = 0;
 
       for (let items of actorData.items) {
         if (items.data.type === "armor" && items.data.data.equip === true) {

--- a/module/expanse.js
+++ b/module/expanse.js
@@ -21,7 +21,7 @@ Hooks.once("init", async function () {
   CONFIG.Actor.documentClass = ExpanseActor;
   CONFIG.Item.documentClass = ExpanseItem;
   CONFIG.Combat.initiative = {
-    formula: "3d6+@abilities.dexterity.rating",
+    formula: "3d6+@abilities.dexterity.rating+@attributes.penalty.modified",
     decimals: 2
   }
   CONFIG.Dice.terms["a"] = TheExpanseEarthDark;

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -113,6 +113,7 @@ export class ExpanseItemSheet extends ItemSheet {
             itemData.data.npcAttack = data.data.data.npcattack;
             itemData.data.usefocus = data.data.data.usefocus;
             itemData.data.usefocusplus = data.data.data.usefocusplus;
+            itemData.data.usepenalty = data.data.data.usepenalty;
             itemData.data.damage = data.data.data.damage;
             itemData.data.manualDamage = data.data.data.manualDamage;
             itemData.data.hasBonusDamage = data.data.data.hasBonusDamage;

--- a/styles/expanse.css
+++ b/styles/expanse.css
@@ -464,6 +464,22 @@ blockquote {
     text-transform: uppercase;
     align-items: center;
 }
+
+.ability-penalty-box {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 0px 0px 0px 50px;
+}
+
+.ability-penalty-box > span {
+    font-size: .8em;
+    text-transform: uppercase;
+    align-items: center;
+}
+
   
 .age-abilities input[type=text] {
     display: flex;

--- a/template.json
+++ b/template.json
@@ -103,7 +103,8 @@
                     "rating": 0,
                     "focus": "",
                     "useFocus": false,
-                    "useFocusPlus": false
+                    "useFocusPlus": false,
+                    "usePenalty": false
                 },
                 "fighting": {
                     "rating": 0,

--- a/templates/sheet/character-sheet.html
+++ b/templates/sheet/character-sheet.html
@@ -202,6 +202,14 @@
 
                             <span>{{key}}</span>
 
+                            {{#ifCond key '==' 'dexterity'}}
+                            <div class="ability-penalty-box">
+                                <span>Penalty</span>
+                                <input type="checkbox" class="expanse-checkbox" name="data.abilities.{{key}}.usePenalty"
+                                       {{checked ability.usePenalty}}>
+                            </div>
+                            {{/ifCond}}
+
                             <div class="ability-focus-box">
                                 <span>Focus +2</span>
                                 <input type="checkbox" class="expanse-checkbox" name="data.abilities.{{key}}.useFocus"


### PR DESCRIPTION
Closes #32. A fix of a bunch of armor issues. Armor penalties are automatically applied to movement and initiative. Armor penalties have a checkbox that allows the user to apply a penalty to DEX rolls called "penalty". This is done so some types of DEX rolls, for example piloting, don't have to be affected just because your wearing light armor. You can only equip one armor and one shield at a time.
