### PR TITLE
Foundry VTT v11 migration

### DIFF
--- a/system.json
+++ b/system.json
@@ -60,9 +60,9 @@
   "gridUnits": "m",
   "primaryTokenAttribute": "attributes.fortune",
   "secondaryTokenAttribute": "resource2",
-  "url": "https://github.com/ieuanmeredith/expanse",
-  "manifest": "https://github.com/ieuanmeredith/expanse/releases/latest/download/system.json",
-  "download": "https://github.com/ieuanmeredith/expanse/releases/download/1.1.0/expanse.zip",
+  "url": "https://github.com/Foxfyre/expanse",
+  "manifest": "https://github.com/Foxfyre/expanse/releases/latest/download/system.json",
+  "download": "https://github.com/Foxfyre/expanse/releases/download/1.1.0/expanse.zip",
   "license": "LICENSE.txt",
   "compatibility": {
     "minimum": "10",

--- a/system.json
+++ b/system.json
@@ -5,9 +5,9 @@
   "version": "1.1.0",
   "authors": [
     {
-      "name": "ieuanmeredith",
-      "email": "ieuanmeredith2204@gmail.com",
-      "discord": "ieuanmeredith#2204",
+      "name": "Foxfyre",
+      "email": "Foxfyre2204@gmail.com",
+      "discord": "Foxfyre#2204",
       "flags": {}
     },
     {
@@ -51,7 +51,7 @@
   "media": [
     {
       "type": "cover",
-      "url": "https://github.com/ieuanmeredith/expanse/blob/48754e8d372787dc421144561a92d8590410bac7/ui/expanse-cover.jpg",
+      "url": "https://github.com/Foxfyre/expanse/blob/48754e8d372787dc421144561a92d8590410bac7/ui/expanse-cover.jpg",
       "loop": false,
       "flags": {}
     }

--- a/system.json
+++ b/system.json
@@ -5,9 +5,9 @@
   "version": "1.1.0",
   "authors": [
     {
-      "name": "Foxfyre",
-      "email": "foxfyre2204@gmail.com",
-      "discord": "Foxfyre#2204",
+      "name": "ieuanmeredith",
+      "email": "ieuanmeredith2204@gmail.com",
+      "discord": "ieuanmeredith#2204",
       "flags": {}
     },
     {
@@ -51,7 +51,7 @@
   "media": [
     {
       "type": "cover",
-      "url": "https://github.com/Foxfyre/expanse/blob/48754e8d372787dc421144561a92d8590410bac7/ui/expanse-cover.jpg",
+      "url": "https://github.com/ieuanmeredith/expanse/blob/48754e8d372787dc421144561a92d8590410bac7/ui/expanse-cover.jpg",
       "loop": false,
       "flags": {}
     }
@@ -60,9 +60,9 @@
   "gridUnits": "m",
   "primaryTokenAttribute": "attributes.fortune",
   "secondaryTokenAttribute": "resource2",
-  "url": "https://github.com/Foxfyre/expanse",
-  "manifest": "https://github.com/Foxfyre/expanse/releases/latest/download/system.json",
-  "download": "https://github.com/Foxfyre/expanse/releases/download/1.0.3/expanse.zip",
+  "url": "https://github.com/ieuanmeredith/expanse",
+  "manifest": "https://github.com/ieuanmeredith/expanse/releases/latest/download/system.json",
+  "download": "https://github.com/ieuanmeredith/expanse/releases/download/1.1.0/expanse.zip",
   "license": "LICENSE.txt",
   "compatibility": {
     "minimum": "10",

--- a/system.json
+++ b/system.json
@@ -67,6 +67,6 @@
   "compatibility": {
     "minimum": "10",
     "verified": "10.291",
-    "maximum": "10"
+    "maximum": "11"
   }
 }

--- a/system.json
+++ b/system.json
@@ -6,7 +6,7 @@
   "authors": [
     {
       "name": "Foxfyre",
-      "email": "Foxfyre2204@gmail.com",
+      "email": "foxfyre2204@gmail.com",
       "discord": "Foxfyre#2204",
       "flags": {}
     },

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "expanse",
   "title": "The Expanse RPG (AGE)",
   "description": "The official system for The Expanse RPG (AGE) from Green Ronin Publishing",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "authors": [
     {
       "name": "Foxfyre",


### PR DESCRIPTION
Enables system to be used on Foundry VTT V11.

Can be installed and tested on v11 via release on the forked repo 

[https://github.com/ieuanmeredith/expanse/releases/download/1.1.0/system.json](https://github.com/ieuanmeredith/expanse/releases/download/1.1.0/system.json)